### PR TITLE
fix: add .env to .gitignore and add .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copy this file to .env and fill in your values
+# Never commit .env to version control
+
+GEMINI_API_KEY=your_gemini_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+# Environment variables
+.env


### PR DESCRIPTION
Prevents the committed `.env` file from being tracked going forward and
adds a `.env.example` template so contributors know what variables are
needed.

Changes:
- Add `.env` to `.gitignore`
- Add `.env.example` with `GEMINI_API_KEY` placeholder

Note: The live key in git history still needs to be rotated in Google
Cloud console and purged from history via `git filter-repo` or BFG —
this PR stops future commits of secrets but does not rewrite history.

Closes #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added environment configuration template for API key setup
  * Updated configuration to prevent sensitive environment files from version control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->