### PR TITLE
Docs/code of conduct and license

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,105 @@
+# Code of Conduct
+
+**Table Of Contents**  
+[Our Pledge](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#our-pledge)  
+[Our Standards](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#our-standards)  
+[ELUSOC Community Standards](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#elusoc-community-standards)  
+[Scope](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#scope)  
+[Enforcement](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#enforcement)  
+[Attribution](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#attribution)  
+
+## Our Pledge
+
+We, as members, contributors, and maintainers of **Digital Ally**, pledge to make participation in our project and community a harassment-free experience for everyone — regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We are committed to fostering an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+## Our Standards
+
+### ✅ Positive Behavior
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy and kindness toward other community members
+- Giving credit where credit is due
+- Helping newcomers and first-time contributors feel welcome
+
+### ❌ Unacceptable Behavior
+
+Examples of behavior that will not be tolerated:
+
+- The use of sexualized language or imagery, and unwelcome sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment of any kind
+- Publishing others' private information (e.g., physical or email address) without explicit permission
+- Spam, self-promotion outside designated channels, or deliberately derailing discussions
+- Dismissing or discouraging contributions without constructive feedback
+- Other conduct that could reasonably be considered inappropriate in a professional setting
+
+---
+
+## ELUSOC Community Standards
+
+As a project participating in the **ELUSOC** open-source program, additional expectations apply:
+
+- Introduce yourself in issues before starting work
+- Post progress updates so maintainers can coordinate effectively
+- If you assign yourself to an issue, provide an update within **20 hours**
+- After **24 hours** of inactivity on an assigned issue, you may be unassigned so others can contribute
+- Keep pull requests focused and well-documented with a clear link to the related issue
+- Respect the contribution review process — be patient and responsive to feedback
+
+---
+
+## Scope
+
+This Code of Conduct applies to all project spaces, including:
+
+- GitHub Issues, Pull Requests, and Discussions
+- Code reviews and comments
+- The project repository and all associated documentation
+- Any communication channels used by the project community (e.g., Discord, Slack, forums)
+
+It also applies when an individual is officially representing the project in public spaces.
+
+---
+
+## Enforcement
+
+### Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by:
+
+1. Opening a **Security Report** using the [Security tab](SECURITY.md) in this repository
+2. Contacting the project maintainers directly via GitHub
+
+All complaints will be reviewed and investigated promptly and fairly. The project team is obligated to maintain confidentiality with regard to the reporter of an incident.
+
+### Consequences
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that do not align with this Code of Conduct. They may also temporarily or permanently ban any contributor whose behavior is deemed inappropriate, threatening, offensive, or harmful.
+
+The following enforcement ladder applies:
+
+| Severity | Consequence |
+|----------|-------------|
+| **1 — Correction** | Private written warning; clarification of why the behavior was inappropriate |
+| **2 — Warning** | Public warning; restriction from interaction with the community for a specified period |
+| **3 — Temporary Ban** | Temporary removal from all community interaction and contribution |
+| **4 — Permanent Ban** | Permanent removal from the project community |
+
+---
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, and the [GitHub Community Guidelines](https://docs.github.com/en/site-policy/github-terms/github-community-guidelines).
+
+For answers to common questions about this code of conduct, see the [Contributor Covenant FAQ](https://www.contributor-covenant.org/faq).
+
+---

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,12 @@
 # Code of Conduct
 
 **Table Of Contents**  
-[Our Pledge](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#our-pledge)  
-[Our Standards](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#our-standards)  
-[ELUSOC Community Standards](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#elusoc-community-standards)  
-[Scope](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#scope)  
-[Enforcement](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#enforcement)  
-[Attribution](https://github.com/Rohan-Shridhar/Digital-Ally/new/docs/code-of-conduct-and-license#attribution)  
+[Our Pledge](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#our-pledge)  
+[Our Standards](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#our-standards)  
+[ELUSOC Community Standards](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#elusoc-community-standards)  
+[Scope](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#scope)  
+[Enforcement](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#enforcement)  
+[Attribution](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#attribution)  
 
 ## Our Pledge
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,12 +1,12 @@
 # Code of Conduct
 
 **Table Of Contents**  
-[Our Pledge](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#our-pledge)  
-[Our Standards](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#our-standards)  
-[ELUSOC Community Standards](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#elusoc-community-standards)  
-[Scope](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#scope)  
-[Enforcement](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#enforcement)  
-[Attribution](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license?tab=coc-ov-file#attribution)  
+[Our Pledge](`#our-pledge`)  
+[Our Standards](`#our-standards`)  
+[ELUSOC Community Standards](`#elusoc-community-standards`)  
+[Scope](`#scope`)  
+[Enforcement](`#enforcement`)  
+[Attribution](`#attribution`)  
 
 ## Our Pledge
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 vallabhatech
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- What does this PR change?
 *This PR is focused on adding CODE_OF_CONDUCT and LICENSE*

## Related Issues
closes #17 

## Type of change
- [x] Enhancement
- [x] Documentation


## Verification
Open branch [docs/code of conduct and license](https://github.com/Rohan-Shridhar/Digital-Ally/tree/docs/code-of-conduct-and-license)

## Additional context
- Anything reviewers should know.
*I have added a table of contents in CODE_OF_CONDUCT, lmk if you don't need it*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive Code of Conduct covering community pledge, positive and unacceptable behaviors, project-specific standards, scope, enforcement procedures with severity levels, reporting mechanisms, and attribution/links to related resources.

* **Chores**
  * Updated project license to the MIT License and added copyright attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->