### PR TITLE
[ELUSOC]Add translation checks and new dashboard copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "npm run check:translations && vite build",
+    "check:translations": "node scripts/check-translations.mjs",
     "preview": "vite preview",
     "start:server": "node server/index.js"
   },

--- a/scripts/check-translations.mjs
+++ b/scripts/check-translations.mjs
@@ -1,0 +1,156 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import ts from 'typescript';
+
+const rootDirectory = process.cwd();
+const sourceDirectory = path.join(rootDirectory, 'src');
+const constantsPath = path.join(sourceDirectory, 'constants.ts');
+
+const parseFile = (filePath) => ts.createSourceFile(
+  filePath,
+  fs.readFileSync(filePath, 'utf8'),
+  ts.ScriptTarget.Latest,
+  true,
+  filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+);
+
+const getPropertyName = (property) => {
+  if (!property.name) return null;
+  if (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) {
+    return property.name.text;
+  }
+  return null;
+};
+
+const constantsSource = parseFile(constantsPath);
+const translations = new Map();
+const configuredLocales = new Set();
+const dynamicTranslationKeys = new Set();
+
+const visitConstants = (node) => {
+  if (
+    ts.isVariableDeclaration(node)
+    && ts.isIdentifier(node.name)
+    && node.initializer
+    && ts.isArrayLiteralExpression(node.initializer)
+  ) {
+    const target = node.name.text === 'LANGUAGES'
+      ? { propertyName: 'value', values: configuredLocales }
+      : node.name.text === 'COLOR_PALETTES'
+        ? { propertyName: 'name', values: dynamicTranslationKeys }
+        : null;
+
+    if (target) {
+      for (const element of node.initializer.elements) {
+        if (!ts.isObjectLiteralExpression(element)) continue;
+        for (const property of element.properties) {
+          if (
+            ts.isPropertyAssignment(property)
+            && getPropertyName(property) === target.propertyName
+            && ts.isStringLiteral(property.initializer)
+          ) {
+            target.values.add(property.initializer.text);
+          }
+        }
+      }
+    }
+  }
+
+  if (
+    ts.isVariableDeclaration(node)
+    && ts.isIdentifier(node.name)
+    && node.name.text === 'TRANSLATIONS'
+    && node.initializer
+    && ts.isObjectLiteralExpression(node.initializer)
+  ) {
+    for (const localeProperty of node.initializer.properties) {
+      if (!ts.isPropertyAssignment(localeProperty)) continue;
+
+      const locale = getPropertyName(localeProperty);
+      if (!locale || !ts.isObjectLiteralExpression(localeProperty.initializer)) continue;
+
+      const keys = new Set();
+      for (const translationProperty of localeProperty.initializer.properties) {
+        const key = getPropertyName(translationProperty);
+        if (key) keys.add(key);
+      }
+      translations.set(locale, keys);
+    }
+  }
+
+  ts.forEachChild(node, visitConstants);
+};
+
+visitConstants(constantsSource);
+
+if (translations.size === 0) {
+  console.error('Translation coverage failed: TRANSLATIONS could not be read.');
+  process.exit(1);
+}
+
+const sourceFiles = [];
+const collectSourceFiles = (directory) => {
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    const entryPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      collectSourceFiles(entryPath);
+    } else if (entry.isFile() && /\.(ts|tsx)$/.test(entry.name)) {
+      sourceFiles.push(entryPath);
+    }
+  }
+};
+
+collectSourceFiles(sourceDirectory);
+
+const usedKeys = new Set();
+for (const filePath of sourceFiles) {
+  const source = parseFile(filePath);
+  const visitCalls = (node) => {
+    if (
+      ts.isCallExpression(node)
+      && ts.isIdentifier(node.expression)
+      && node.expression.text === 't'
+      && node.arguments.length > 0
+      && ts.isStringLiteral(node.arguments[0])
+    ) {
+      usedKeys.add(node.arguments[0].text);
+    }
+    ts.forEachChild(node, visitCalls);
+  };
+  visitCalls(source);
+}
+for (const key of dynamicTranslationKeys) usedKeys.add(key);
+
+const allDefinedKeys = new Set(
+  [...translations.values()].flatMap((keys) => [...keys]),
+);
+const failures = [];
+
+for (const locale of configuredLocales) {
+  if (!translations.has(locale)) {
+    failures.push(`${locale} is configured in LANGUAGES but has no translation table`);
+  }
+}
+
+for (const [locale, keys] of translations) {
+  const missingDefinedKeys = [...allDefinedKeys].filter((key) => !keys.has(key));
+  const missingUsedKeys = [...usedKeys].filter((key) => !keys.has(key));
+
+  if (missingDefinedKeys.length > 0) {
+    failures.push(`${locale} is missing locale keys: ${missingDefinedKeys.sort().join(', ')}`);
+  }
+  if (missingUsedKeys.length > 0) {
+    failures.push(`${locale} is missing used keys: ${missingUsedKeys.sort().join(', ')}`);
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`Translation coverage failed:\n- ${failures.join('\n- ')}`);
+  process.exit(1);
+}
+
+console.log(
+  `Translation coverage passed: ${translations.size} locales, `
+  + `${allDefinedKeys.size} consistent keys, ${usedKeys.size} static UI keys checked.`,
+);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,10 @@ export const COLOR_PALETTES = [
 
 export const TRANSLATIONS: { [key: string]: { [key: string]: string } } = {
   'en-US': {
+    dashboardSubtext: 'Manage your business performance and online presence in one place.',
+    websiteManagement: 'Website Management',
+    websiteManagementSubtext: 'View your generated website or make changes to it.',
+    viewWebsite: 'View Website',
     generator: 'Generator',
     dashboard: 'Dashboard',
     examples: 'Examples',
@@ -97,6 +101,11 @@ export const TRANSLATIONS: { [key: string]: { [key: string]: string } } = {
     customizeWebsite: 'View & Customize',
   },
   'te-IN': {
+    headline2: 'మీ వెబ్‌సైట్‌ను పొందండి.',
+    dashboardSubtext: 'మీ వ్యాపార పనితీరు మరియు ఆన్‌లైన్ ఉనికిని ఒకే చోట నిర్వహించండి.',
+    websiteManagement: 'వెబ్‌సైట్ నిర్వహణ',
+    websiteManagementSubtext: 'మీరు రూపొందించిన వెబ్‌సైట్‌ను వీక్షించండి లేదా మార్చండి.',
+    viewWebsite: 'వెబ్‌సైట్‌ను వీక్షించండి',
     generator: 'జెనరేటర్',
     dashboard: 'డాష్‌బోర్డ్',
     examples: 'ఉదాహరణలు',
@@ -179,6 +188,11 @@ export const TRANSLATIONS: { [key: string]: { [key: string]: string } } = {
     customizeWebsite: 'వీక్షించండి & అనుకూలీకరించండి',
   },
   'hi-IN': {
+    headline2: 'अपनी वेबसाइट पाएं।',
+    dashboardSubtext: 'अपने व्यवसाय के प्रदर्शन और ऑनलाइन उपस्थिति को एक ही जगह प्रबंधित करें।',
+    websiteManagement: 'वेबसाइट प्रबंधन',
+    websiteManagementSubtext: 'अपनी बनाई गई वेबसाइट देखें या उसमें बदलाव करें।',
+    viewWebsite: 'वेबसाइट देखें',
     generator: 'जेनरेटर',
     dashboard: 'डैशबोर्ड',
     examples: 'उदाहरण',


### PR DESCRIPTION
## Summary
- Adds missing dashboard translation keys for English, Telugu, and Hindi.
- Adds an automated translation coverage check to prevent undefined or inconsistent keys.

Fixes #20 

## Type of change
- [x] Bug fix
- [ ] Enhancement
- [ ] Documentation
- [x] Testing
- [ ] UI/UX
- [ ] Security
- [ ] Performance

## Verification
- [x] Ran `npm run build` — attempted, but blocked by pre-existing TypeScript/Vite configuration issues.
- [x] Ran `npm run test` (not applicable)
- [x] Ran `npm run check:translations` — passed for all 3 languages.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized strings supporting dashboard and website management features across English, Telugu, and Hindi.

* **Chores**
  * Build process updated to include translation validation, ensuring all configured languages have consistent translation coverage before compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->