### PR TITLE
feat: add scroll to top button (#100)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -6,6 +6,7 @@ import { ResultPage } from '@/pages/ResultPage';
 import { DashboardPage } from '@/pages/DashboardPage';
 import { LoadingSpinner } from '@/components/LoadingSpinner';
 import { PrivacyModal } from '@/components/PrivacyModal';
+import { ScrollToTop } from '@/components/ScrollToTop';
 
 const AppContent: React.FC = () => {
   const context = useContext(AppContext);
@@ -27,6 +28,7 @@ const AppContent: React.FC = () => {
         {pageState === 'result' && <ResultPage />}
         {pageState === 'dashboard' && <DashboardPage />}
       </main>
+      <ScrollToTop />
       {!privacyMode && <PrivacyModal onChoose={setPrivacyMode} />}
     </div>
   );

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,39 @@
+import React, { useState, useEffect } from 'react';
+
+export const ScrollToTop: React.FC = () => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, []);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <button
+      onClick={scrollToTop}
+      className="fixed bottom-6 right-6 p-3 bg-lime-600 text-white rounded-full shadow-lg hover:bg-lime-700 transition-colors z-50 focus:outline-none focus:ring-2 focus:ring-lime-500 focus:ring-offset-2"
+      aria-label="Scroll to top"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="m18 15-6-6-6 6"/>
+      </svg>
+    </button>
+  );
+};


### PR DESCRIPTION
## Summary
Fixes #100

Added a \\ScrollToTop\\ button to improve navigation for users with long content pages. 

## Changes
- Created \\src/components/ScrollToTop.tsx\\ with standard React hooks (useState, useEffect) to track scroll position
- Integrated the component into the main \\App.tsx\\ layout
- The button smoothly scrolls the user back to the top when clicked
- Button appears only after scrolling down 300px
- Used Tailwind CSS for styling and responsiveness